### PR TITLE
Fix soundness and ergonomics with new `AlignedBuf` type

### DIFF
--- a/gvariant-macro/src/generate_impl.rs
+++ b/gvariant-macro/src/generate_impl.rs
@@ -94,10 +94,9 @@ fn write_non_fixed_size_structure(
         }}
     }}
     impl ToOwned for Structure{spec} {{
-        type Owned = Box<Self>;
+        type Owned = Owned<Self>;
         fn to_owned(&self) -> Self::Owned {{
-            let cp = self.data.to_owned();
-            unsafe {{ Box::from_raw(Self::from_aligned_slice_mut(Box::leak(cp)) as *mut Self) }}
+            Owned::from_bytes(&*self.data)
         }}
     }}
     impl ::gvariant::Cast for Structure{spec} {{

--- a/gvariant/src/aligned_bytes.rs
+++ b/gvariant/src/aligned_bytes.rs
@@ -228,11 +228,9 @@ impl<A: Alignment> PartialEq for AlignedSlice<A> {
 
 #[cfg(feature = "alloc")]
 impl<A: Alignment> ToOwned for AlignedSlice<A> {
-    type Owned = Box<AlignedSlice<A>>;
+    type Owned = AlignedBuf;
     fn to_owned(&self) -> Self::Owned {
-        let mut owned = alloc_aligned(self.len());
-        owned.copy_from_slice(self);
-        owned
+        self.data.to_owned().into()
     }
 }
 
@@ -246,9 +244,7 @@ pub fn copy_to_align<A: Alignment>(data: &[u8]) -> Cow<'_, AlignedSlice<A>> {
     if is_aligned_to::<A>(data) {
         Cow::Borrowed(data.try_as_aligned().unwrap())
     } else {
-        let mut copy = alloc_aligned::<A>(data.len());
-        copy.copy_from_slice(data);
-        Cow::Owned(copy)
+        Cow::Owned(data.to_owned().into())
     }
 }
 

--- a/gvariant/src/aligned_bytes.rs
+++ b/gvariant/src/aligned_bytes.rs
@@ -168,10 +168,9 @@ pub struct A8;
 unsafe impl Alignment for A8 {
     const ALIGNMENT: usize = 8;
 }
-unsafe impl AlignedTo<A1> for A8 {}
-unsafe impl AlignedTo<A2> for A8 {}
-unsafe impl AlignedTo<A4> for A8 {}
-unsafe impl AlignedTo<A8> for A8 {}
+
+// A8 is the maximum alignment, so all Alignments must
+unsafe impl<A: Alignment> AlignedTo<A> for A8 {}
 
 /// Allows narrowing the alignment of a `&AlignedSlice`
 ///

--- a/gvariant/src/aligned_bytes.rs
+++ b/gvariant/src/aligned_bytes.rs
@@ -78,10 +78,7 @@
 pub use crate::offset::{align_offset, AlignedOffset};
 
 #[cfg(feature = "alloc")]
-use alloc::{
-    borrow::{Cow, ToOwned},
-    boxed::Box,
-};
+use alloc::borrow::{Cow, ToOwned};
 use core::ops::{
     Deref, DerefMut, Index, IndexMut, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo,
     RangeToInclusive,
@@ -245,27 +242,6 @@ pub fn copy_to_align<A: Alignment>(data: &[u8]) -> Cow<'_, AlignedSlice<A>> {
         Cow::Borrowed(data.try_as_aligned().unwrap())
     } else {
         Cow::Owned(data.to_owned().into())
-    }
-}
-
-/// Allocate a new boxed [`AlignedSlice`].
-///
-/// Data is initialised to all 0.
-#[cfg(feature = "alloc")]
-pub fn alloc_aligned<A: Alignment>(size: usize) -> Box<AlignedSlice<A>> {
-    let layout = alloc::alloc::Layout::from_size_align(size, A::ALIGNMENT).unwrap();
-    unsafe {
-        // This is safe because:
-        //
-        // * We use the same size here as passed into layout, so the slice only
-        //   points to genuinely allocated memory
-        // * We use alloc_zeroed so the memory is completely initialised
-        // * All zeros is a valid bit pattern for [u8], as is any bit pattern
-        // * We can cast to AlignedSlice because the representation is the same
-        //   as [u8] modulo alignment, and appropriate alignment has been
-        //   specified in layout
-        let bs = core::slice::from_raw_parts_mut(alloc::alloc::alloc_zeroed(layout), size);
-        Box::from_raw(to_alignedslice_unchecked_mut(bs))
     }
 }
 

--- a/gvariant/src/aligned_bytes.rs
+++ b/gvariant/src/aligned_bytes.rs
@@ -95,6 +95,7 @@ use core::{
 };
 #[cfg(feature = "std")]
 use std::io::IoSliceMut;
+use std::marker::PhantomData;
 
 /// A trait for our alignment structs [`A1`], [`A2`], [`A4`] and [`A8`].
 ///
@@ -143,7 +144,6 @@ unsafe impl Alignment for A1 {
 unsafe impl AlignedTo<A1> for A1 {}
 
 /// 2-byte alignment
-#[repr(align(2))]
 #[derive(Debug, Copy, Clone)]
 pub struct A2;
 unsafe impl Alignment for A2 {
@@ -153,7 +153,6 @@ unsafe impl AlignedTo<A1> for A2 {}
 unsafe impl AlignedTo<A2> for A2 {}
 
 /// 4-byte alignment
-#[repr(align(4))]
 #[derive(Debug, Copy, Clone)]
 pub struct A4;
 unsafe impl Alignment for A4 {
@@ -164,7 +163,6 @@ unsafe impl AlignedTo<A2> for A4 {}
 unsafe impl AlignedTo<A4> for A4 {}
 
 /// 8-byte alignment
-#[repr(align(8))]
 #[derive(Debug, Copy, Clone)]
 pub struct A8;
 unsafe impl Alignment for A8 {
@@ -217,14 +215,14 @@ pub trait TryAsAlignedMut<A: Alignment>: TryAsAligned<A> {
     fn try_as_aligned_mut(&mut self) -> Result<&mut AlignedSlice<A>, Misaligned>;
 }
 
-/// A byte array, but with a compile-time guaranteed minimum alignment
+/// A byte array, but tagged with GVariant alignment
 ///
 /// The aligment requirement is specfied by the type parameter A.  It will be
 /// [`A1`], [`A2`], [`A4`] or [`A8`].
-#[repr(C)]
+#[repr(transparent)]
 #[derive(Debug, Eq)]
 pub struct AlignedSlice<A: Alignment> {
-    alignment: A,
+    alignment: PhantomData<A>,
     data: [u8],
 }
 

--- a/gvariant/src/buf.rs
+++ b/gvariant/src/buf.rs
@@ -157,3 +157,34 @@ impl<A: Alignment> Borrow<AlignedSlice<A>> for AlignedBuf {
         (**self).as_aligned()
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::AlignedBuf;
+
+    fn read_to_buf(mut file: impl std::io::Read) -> AlignedBuf {
+        let mut v = vec![];
+        file.read_to_end(&mut v).unwrap();
+        v.into()
+    }
+
+    #[test]
+    fn test_read_to_buf() {
+        let mut d: Vec<u8> = vec![0; 16384];
+        for x in 0..16384 {
+            d[x] = (x % 256) as u8;
+        }
+
+        let s = read_to_buf(b"".as_ref());
+        assert_eq!(**s, *b"");
+
+        let s = read_to_buf(&d[..12]);
+        assert_eq!(**s, d[..12]);
+
+        let s = read_to_buf(&d[..8000]);
+        assert_eq!(**s, d[..8000]);
+
+        let s = read_to_buf(d.as_slice());
+        assert_eq!(&**s, d.as_slice());
+    }
+}

--- a/gvariant/src/buf.rs
+++ b/gvariant/src/buf.rs
@@ -1,0 +1,159 @@
+use core::borrow::Borrow;
+use core::fmt::Debug;
+use core::ops::Deref;
+use core::ops::DerefMut;
+
+use crate::aligned_bytes::{
+    to_alignedslice_unchecked, to_alignedslice_unchecked_mut, AlignedSlice, Alignment, AsAligned,
+    A8,
+};
+
+/// A buffer where the pointed to data is guaranteed to have 8B alignment.  The
+/// length of the data needn't be a multiple of 8.
+///
+/// This is implemented in terms of a [Vec<u8>].  Alignment is maintained by
+/// adding padding at the beginning if the underlying allocation is not 8B
+/// aligned to start with.  In practice the system allocator will always
+/// provide 8B alignment anyway[^1] so conversion between [AlignedBuf] and
+/// [Vec<u8>] will in practice be a noop.
+///
+/// [^1]: except when running under miri.  Please let me know if you come
+///       across an architecture where this is not true.
+pub struct AlignedBuf {
+    data: Vec<u8>,
+}
+
+impl Debug for AlignedBuf {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let x: &[u8] = self.as_ref();
+        std::fmt::Debug::fmt(x, f)
+    }
+}
+
+impl AlignedBuf {
+    /// Create new empty [AlignedBuf].  This does not allocate.
+    pub fn new() -> Self {
+        AlignedBuf { data: vec![] }
+    }
+    /// Run the provided function passing in (a potentially unaligned) vec
+    /// to be modified in-place.
+    ///
+    /// Example: Write into an [AlignedBuf] from file:
+    ///
+    /// ```
+    /// # fn moo(mut file: impl std::io::Read) -> std::io::Result<()> {
+    /// use gvariant::aligned_bytes::AlignedBuf;
+    /// let mut a = AlignedBuf::new();
+    /// a.with_vec(|v| file.read_to_end(v))?;
+    /// # let r : &[u8] = a.as_ref();
+    /// # assert_eq!(r, b"Hello there");
+    /// # Ok(())
+    /// # }
+    /// # moo(b"Hello there".as_ref()).unwrap();
+    /// ```
+    pub fn with_vec<T>(&mut self, f: impl FnOnce(&mut Vec<u8>) -> T) -> T {
+        unalign(&mut self.data);
+        // Panic safety: We align the data again in the
+        // [RealignGuard::drop] so even if the user-provided callback
+        // panics the data will be aligned.  This isn't a safety issue, but
+        // is a correctness one.
+        let guard = RealignGuard(&mut self.data);
+        f(guard.0)
+    }
+}
+/// Implementation detail of with_vec above
+struct RealignGuard<'a>(&'a mut Vec<u8>);
+impl<'a> Drop for RealignGuard<'a> {
+    fn drop(&mut self) {
+        align(self.0)
+    }
+}
+impl Default for AlignedBuf {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+fn offset_to_align(v: &[u8]) -> usize {
+    if v.is_empty() {
+        0
+    } else {
+        let p = &v[0] as *const u8 as usize;
+        let out = p.wrapping_neg() & 7;
+        debug_assert!((p + out) & 7 == 0);
+        out
+    }
+}
+#[inline]
+fn is_aligned(v: &[u8]) -> bool {
+    v.is_empty() || (&v[0] as *const u8 as usize & 7) == 0
+}
+/// Shift the data in Vec to the right such that the data at the start of
+/// the vec is now 8B aligned.
+fn align(data: &mut Vec<u8>) {
+    if !is_aligned(data) {
+        align_cold(data)
+    }
+}
+#[cold]
+#[inline(never)]
+fn align_cold(data: &mut Vec<u8>) {
+    data.reserve(7);
+    let off = offset_to_align(data);
+    data.resize(data.len() + off, 0);
+    data.rotate_right(off)
+}
+/// Shift the data in Vec to the left so as to undo the effects of [wind].
+fn unalign(data: &mut Vec<u8>) {
+    if !is_aligned(data) {
+        unalign_cold(data)
+    }
+}
+#[cold]
+#[inline(never)]
+fn unalign_cold(data: &mut Vec<u8>) {
+    let off = offset_to_align(data);
+    data.rotate_left(off);
+    data.truncate(data.len() - off);
+}
+impl From<Vec<u8>> for AlignedBuf {
+    fn from(mut data: Vec<u8>) -> Self {
+        align(&mut data);
+        Self { data }
+    }
+}
+impl From<AlignedBuf> for Vec<u8> {
+    fn from(mut b: AlignedBuf) -> Self {
+        unalign(&mut b.data);
+        b.data
+    }
+}
+
+impl Deref for AlignedBuf {
+    type Target = AlignedSlice<A8>;
+
+    fn deref(&self) -> &Self::Target {
+        let s = &self.data[offset_to_align(&self.data)..];
+        unsafe {
+            // SAFETY: `s` is guaranteed to be 8B aligned because that's what `offset_to_align` is
+            // for.
+            to_alignedslice_unchecked(s)
+        }
+    }
+}
+impl DerefMut for AlignedBuf {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        let off = offset_to_align(&self.data);
+        let s = &mut self.data[off..];
+        unsafe {
+            // SAFETY: `s` is guaranteed to be 8B aligned because that's what `offset_to_align` is
+            // for.
+            to_alignedslice_unchecked_mut(s)
+        }
+    }
+}
+
+impl<A: Alignment> Borrow<AlignedSlice<A>> for AlignedBuf {
+    fn borrow(&self) -> &AlignedSlice<A> {
+        (**self).as_aligned()
+    }
+}

--- a/gvariant/src/casting.rs
+++ b/gvariant/src/casting.rs
@@ -25,7 +25,6 @@ use std::error::Error;
 
 use crate::aligned_bytes;
 use crate::aligned_bytes::{is_aligned, AlignedSlice};
-use ref_cast::RefCast;
 
 /// If a type implements this trait it's a promise that all representations of
 /// underlying memory are valid for this type.
@@ -95,11 +94,6 @@ pub(crate) fn cast_slice<'a, A: aligned_bytes::Alignment, T: AllBitPatternsValid
     } else {
         Err(WrongSize {})
     }
-}
-
-pub(crate) fn ref_cast_box<T: RefCast + ?Sized>(a: Box<T::From>) -> Box<T> {
-    // We lean on RefCast to make this safe
-    unsafe { Box::from_raw(T::ref_cast_mut(Box::leak(a)) as *mut T) }
 }
 
 /// Safely cast an `&AlignedSlice` to `&T` where `T: Sized`

--- a/gvariant/src/lib.rs
+++ b/gvariant/src/lib.rs
@@ -79,7 +79,7 @@
 //!
 //! * Allocating [`AlignedSlice`]s with [`ToOwned`],
 //!   [`copy_to_align`][aligned_bytes::copy_to_align] and
-//!   [`alloc_aligned`][aligned_bytes::alloc_aligned].
+//!   [`AlignedBuf`].
 //! * The convenience API `Marker::from_bytes` - use `Marker::cast` instead
 //! * Correctly displaying non-utf-8 formatted strings
 //! * Copying unsized GVariant objects with `to_owned()`
@@ -259,6 +259,9 @@
 //!   #     Ok(())
 //!   # }
 //!   ```
+//! * Removed `aligned_bytes::alloc_aligned`.  Use [AlignedBuf] instead.
+//!   According to miri `alloc_aligned` was unsound.  [AlignedBuf] is sound and
+//!   more convenient to use.
 //!
 //! ### New features
 //!
@@ -387,7 +390,7 @@ pub trait Marker: Copy {
     /// This is a convenience API wrapper around `copy_to_align` and `cast`
     /// allowing users to not have to think about the alignment of their data.
     /// It is usually better to ensure the data you have is aligned, for example
-    /// using `alloc_aligned` or `AlignedBuf`, and then use `cast` directly.
+    /// using `copy_to_align` or `AlignedBuf`, and then use `cast` directly.
     /// This way you can avoid additional allocations, avoid additional copying,
     /// and work in noalloc contexts.
     ///


### PR DESCRIPTION
`AlignedBuf` is like a `Vec<u8>`, but explicitly maintains the invariant that the data is 8B aligned.  In practice `Vec<u8>` are always 8B aligned anyway[^1] (except when using miri), which makes conversions to/from `Vec<u8>` free. This simplifies use allowing us to remove `read_to_slice` and `alloc_aligned` and users can use the more standard `Read::read_to_end(Vec<u8>)` instead.