### PR TITLE
gvariant: Fix link to canonical GVariant Specification

### DIFF
--- a/gvariant/src/lib.rs
+++ b/gvariant/src/lib.rs
@@ -41,7 +41,7 @@
 //!
 //! [GLib implementation]: https://developer.gnome.org/glib/stable/glib-GVariant.html
 //! [GVariant Schema Compiler]: https://gitlab.gnome.org/alexl/variant-schema-compiler/
-//! [GVariant specification]: https://people.gnome.org/~desrt/gvariant-serialisation.pdf
+//! [GVariant specification]: https://developer.gnome.org/documentation/specifications/gvariant-specification-1.0.html
 //!
 //! ## Status
 //!


### PR DESCRIPTION
The old PDF has been reformatted and is now hosted on developer.gnome.org.

It will be updated over time with errata, so please follow it for changes.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>